### PR TITLE
Handle invalid configured test dirs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 
 All notable changes to this project will be documented in this file.
 
+Unreleased
+==========
+
+Fixed
+-----
+
+ * Now handles test directories that were valid when configured but were later moved or deleted
+
 0.4.1 - 2017-07-27
 ==================
 

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -188,7 +188,10 @@ class ScriptAssistant:
         tool_button = QToolButton()
         tool_button.setMenu(tool_button_menu)
         # The first action created is the default
-        tool_button.setDefaultAction(tool_button_menu.actions()[0])
+        try:
+            tool_button.setDefaultAction(tool_button_menu.actions()[0])
+        except IndexError:
+            pass
         tool_button.setPopupMode(QToolButton.MenuButtonPopup)
         self.toolbar.addWidget(tool_button)
         return tool_button
@@ -271,7 +274,7 @@ class ScriptAssistant:
         )
         self.test_script_menu.addAction(self.test_all_action)
 
-        if test_folder:
+        if os.path.isdir(test_folder):
             test_file_names = [
                 f[5:-3] for f in os.listdir(test_folder) if
                 f.startswith("test_") and f.endswith(".py")
@@ -493,7 +496,6 @@ class ScriptAssistant:
                 "current_configuration",
                 self.dlg_settings.cmb_config.lineEdit().text()
             )
-
 
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""


### PR DESCRIPTION
Test directories must be valid when originally configured, but can later be moved or deleted. Previously when this happened, an `IndexError` would occur when the plugin was attempting to build and so the plugin could not be reconfigured.

This PR adds additional checks to ensure that the test directory is valid.