### PR TITLE
Include subfolders and print final summary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
     - docker exec -it qgis-testing-environment sh -c "ln -s /tests_directory /root/.qgis2/python/plugins/${PLUGIN_NAME}"
 
 script:
-    - docker exec -it qgis-testing-environment sh -c "qgis_testrunner.sh ${PLUGIN_NAME}.tests.test_script_assistant.run_tests"
+    - docker exec -it qgis-testing-environment sh -c "qgis_testrunner.sh ${PLUGIN_NAME}.tests.run_tests"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 Unreleased
 ==========
 
+Added
+-----
+
+ * A final summary of the test results is printed to the QGIS Python Console after all testing
+
+Changed
+-------
+
+ * Subfolders are now included in test discovery
+
 Fixed
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Changed
 
  * Subfolders are now included in test discovery
 
+Removed
+-------
+
+ * The option to run plugin tests with a delay and repaint has been removed due to inconsistent behaviour
+
 Fixed
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 
 All notable changes to this project will be documented in this file.
 
+Unreleased
+==========
+
+Fixed
+-----
+
+ * Now handles test directories that were valid when configured but were later moved or deleted
+
 0.4.1 - 2017-07-27
 ==================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,16 +36,6 @@ Don't reload tests setting
 
 This setting turns off the use of ``reload()`` to reload test modules. It'll run tests faster but the test won't update if it has been edited in an external text editor.
 
-Playback UI tests in slow motion setting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. image:: images/playback_ui_tests.png
-    :align: center
-
-This setting requires some additional code within the tests to actually do anything.
-
-This setting simply calls ``test_x.run_tests(view_tests=True)`` instead of ``test_x.run_tests()``. The ``view_tests`` parameter is used to include a function in testing that repaints Qt widgets and sleeps for a designated time period. This allows UI tests to be visualised.
-
 Directory validation
 --------------------
 

--- a/scriptassistant/gui/settings_dialog.py
+++ b/scriptassistant/gui/settings_dialog.py
@@ -44,7 +44,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
         self.cmb_config.lineEdit().textChanged.connect(self.check_changes)
         self.cmb_config.currentIndexChanged.connect(self.check_changes)
         self.chk_reload.stateChanged.connect(self.check_changes)
-        self.chk_repaint.stateChanged.connect(self.check_changes)
 
     @pyqtSlot()
     def save_configuration(self):
@@ -55,10 +54,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
             no_reload_value = "Y"
         else:
             no_reload_value = "N"
-        if self.chk_repaint.isChecked():
-            view_tests_value = "Y"
-        else:
-            view_tests_value = "N"
 
         # Save to system
         settings = QSettings(
@@ -86,7 +81,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
         settings.setValue("test_data_folder", self.lne_test_data.text())
         settings.setValue("test_folder", self.lne_test.text())
         settings.setValue("no_reload", no_reload_value)
-        settings.setValue("view_tests", view_tests_value)
         settings.endArray()
 
         config_names = [self.cmb_config.itemText(i) for i in range(self.cmb_config.count())]
@@ -128,7 +122,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
             settings.setValue("test_data_folder", config[item]["test_data_folder"])
             settings.setValue("test_folder", config[item]["test_folder"])
             settings.setValue("no_reload", config[item]["no_reload"])
-            settings.setValue("view_tests", config[item]["view_tests"])
         settings.endArray()
 
         if self.cmb_config.count() == 0:
@@ -137,7 +130,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
             self.lne_test.setText("")
             self.lne_test_data.setText("")
             self.chk_reload.setChecked(False)
-            self.chk_repaint.setChecked(False)
         else:
             self.show_configuration()
 
@@ -158,7 +150,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
                 "test_data_folder": settings.value("test_data_folder"),
                 "test_folder": settings.value("test_folder"),
                 "no_reload": settings.value("no_reload"),
-                "view_tests": settings.value("view_tests"),
             }
         settings.endArray()
         return config
@@ -179,10 +170,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
             self.chk_reload.setChecked(True)
         elif settings.value("no_reload") == "N":
             self.chk_reload.setChecked(False)
-        if settings.value("view_tests") == "Y":
-            self.chk_repaint.setChecked(True)
-        elif settings.value("view_tests") == "N":
-            self.chk_repaint.setChecked(False)
         settings.endArray()
 
     @pyqtSlot()
@@ -227,10 +214,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
             no_reload_value = "Y"
         else:
             no_reload_value = "N"
-        if self.chk_repaint.isChecked():
-            view_tests_value = "Y"
-        else:
-            view_tests_value = "N"
 
         # Retrieve from system
         settings = QSettings(
@@ -245,8 +228,7 @@ class SettingsDialog(QDialog, FORM_CLASS):
                 self.lne_script.text() == settings.value("script_folder") and \
                 self.lne_test.text() == settings.value("test_folder") and \
                 self.lne_test_data.text() == settings.value("test_data_folder") and \
-                no_reload_value == settings.value("no_reload") and \
-                view_tests_value == settings.value("view_tests"):
+                no_reload_value == settings.value("no_reload"):
             self.btn_save.setEnabled(False)
             self.setWindowTitle("Script Assistant Configuration")
         else:
@@ -293,10 +275,6 @@ class SettingsDialog(QDialog, FORM_CLASS):
             self.chk_reload.setChecked(True)
         elif settings_manager.load_setting("no_reload") == "N":
             self.chk_reload.setChecked(False)
-        if settings_manager.load_setting("view_tests") == "Y":
-            self.chk_repaint.setChecked(True)
-        elif settings_manager.load_setting("view_tests") == "N":
-            self.chk_repaint.setChecked(False)
 
     def closeEvent(self, event):
         self.closingDialog.emit()

--- a/scriptassistant/gui/settings_dialog.ui
+++ b/scriptassistant/gui/settings_dialog.ui
@@ -7,13 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>380</width>
-    <height>350</height>
+    <height>343</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Script Assistant Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="13" column="0">
+    <widget class="QCheckBox" name="chk_reload">
+     <property name="text">
+      <string>Don't reload tests (faster but static)</string>
+     </property>
+    </widget>
+   </item>
    <item row="12" column="0">
     <layout class="QHBoxLayout" name="hly_test_data">
      <item>
@@ -46,105 +53,12 @@
      </item>
     </layout>
    </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="lbl_test_data">
-     <property name="text">
-      <string>Select a folder to load test data from</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QCheckBox" name="chk_reload">
-     <property name="text">
-      <string>Don't reload tests (faster but static)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="0">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lbl_script">
-     <property name="text">
-      <string>Select a folder to load scripts from</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="lbl_test">
-     <property name="text">
-      <string>Select a folder to load tests from</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="lbl_config">
      <property name="text">
       <string>Configurations</string>
      </property>
     </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="hly_config">
-     <item>
-      <widget class="QComboBox" name="cmb_config">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="editable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btn_save">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Save</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btn_delete">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>50</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Delete</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item row="10" column="0">
     <layout class="QHBoxLayout" name="hly_test">
@@ -210,7 +124,7 @@
      </item>
     </layout>
    </item>
-   <item row="16" column="0">
+   <item row="15" column="0">
     <spacer name="vsp_bottom">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -225,6 +139,85 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="hly_config">
+     <item>
+      <widget class="QComboBox" name="cmb_config">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btn_save">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btn_delete">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="lbl_test_data">
+     <property name="text">
+      <string>Select a folder to load test data from</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="lbl_script">
+     <property name="text">
+      <string>Select a folder to load scripts from</string>
+     </property>
+    </widget>
    </item>
    <item row="2" column="0">
     <spacer name="vsp_top">
@@ -242,10 +235,10 @@
      </property>
     </spacer>
    </item>
-   <item row="14" column="0">
-    <widget class="QCheckBox" name="chk_repaint">
+   <item row="9" column="0">
+    <widget class="QLabel" name="lbl_test">
      <property name="text">
-      <string>Playback UI tests in slow motion</string>
+      <string>Select a folder to load tests from</string>
      </property>
     </widget>
    </item>
@@ -262,7 +255,6 @@
   <tabstop>lne_test_data</tabstop>
   <tabstop>btn_test_data</tabstop>
   <tabstop>chk_reload</tabstop>
-  <tabstop>chk_repaint</tabstop>
   <tabstop>button_box</tabstop>
  </tabstops>
  <resources/>

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -439,7 +439,7 @@ class ScriptAssistant:
 
         Optionally reload and view depending on settings.
         """
-        module = import_module("{0}".format(test_name))
+        module = import_module(test_name)
         # have to reload otherwise a QGIS restart is required after changes
         if gui.settings_manager.load_setting("no_reload") == "Y":
             pass

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -471,7 +471,8 @@ class ScriptAssistant:
                 )
                 result = run_tests()
         else:
-            result = run_tests()
+            suite = unittest.TestLoader().loadTestsFromModule(module)
+            result = unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)
         return result
 
     @pyqtSlot()

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -378,18 +378,27 @@ class ScriptAssistant:
         """Print a summary of all tests to the QGIS Python Console"""
         if self.aggregated_test_result.testsRun:
             print ""
-            for e in self.aggregated_test_result.errors:
-                print e[0]
-                print "-" * len(e[0].__str__())
-                print e[1]
+            if self.aggregated_test_result.errors:
+                print "ERRORS:\n"
+                for error in self.aggregated_test_result.errors:
+                    print error[0]
+                    print "-" * len(error[0].__str__())
+                    print "{0}\n".format(error[1])
+            if self.aggregated_test_result.failures:
+                print "FAILURES:\n"
+                for failure in self.aggregated_test_result.failures:
+                    print failure[0]
+                    print "-" * len(failure[0].__str__())
+                    print "{0}\n".format(failure[1])
+            if self.aggregated_test_result.unexpectedSuccesses:
+                print "UNEXPECTED SUCCESSES:\n"
+                for unexpected in self.aggregated_test_result.unexpectedSuccesses:
+                    print unexpected
                 print ""
-            for f in self.aggregated_test_result.failures:
-                print f[0]
-                print "-" * len(f[0].__str__())
-                print f[1]
-                print ""
-            for g in self.aggregated_test_result.unexpectedSuccesses:
-                print "UNEXPECTED SUCCESS: {0}".format(g)
+            if self.aggregated_test_result.skipped:
+                print "SKIPPED:\n"
+                for skip in self.aggregated_test_result.skipped:
+                    print "{0} - {1}".format(skip[0], skip[1])
                 print ""
 
             successes = self.aggregated_test_result.testsRun - (
@@ -400,12 +409,18 @@ class ScriptAssistant:
                 len(self.aggregated_test_result.skipped)
             )
 
-            self.print_table_row("Successes", successes)
-            self.print_table_row("Errors", len(self.aggregated_test_result.errors))
-            self.print_table_row("Failures", len(self.aggregated_test_result.failures))
-            self.print_table_row("Expected Failures", len(self.aggregated_test_result.expectedFailures))
-            self.print_table_row("Unexpected Successes", len(self.aggregated_test_result.unexpectedSuccesses))
-            self.print_table_row("Skipped", len(self.aggregated_test_result.skipped))
+            self.print_table_row(
+                "Successes", successes)
+            self.print_table_row(
+                "Errors", len(self.aggregated_test_result.errors))
+            self.print_table_row(
+                "Failures", len(self.aggregated_test_result.failures))
+            self.print_table_row(
+                "Expected Failures", len(self.aggregated_test_result.expectedFailures))
+            self.print_table_row(
+                "Unexpected Successes", len(self.aggregated_test_result.unexpectedSuccesses))
+            self.print_table_row(
+                "Skipped", len(self.aggregated_test_result.skipped))
 
             print """+===========================+============+
 | Total                     |       {total: >{fill}} |
@@ -416,9 +431,7 @@ class ScriptAssistant:
             )
 
         else:
-            print ""
-            print "No tests were run."
-            print ""
+            print "\nNo tests were run.\n"
 
     @staticmethod
     def print_table_row(result_type, count):

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -188,7 +188,10 @@ class ScriptAssistant:
         tool_button = QToolButton()
         tool_button.setMenu(tool_button_menu)
         # The first action created is the default
-        tool_button.setDefaultAction(tool_button_menu.actions()[0])
+        try:
+            tool_button.setDefaultAction(tool_button_menu.actions()[0])
+        except IndexError:
+            pass
         tool_button.setPopupMode(QToolButton.MenuButtonPopup)
         self.toolbar.addWidget(tool_button)
         return tool_button
@@ -271,7 +274,7 @@ class ScriptAssistant:
         )
         self.test_script_menu.addAction(self.test_all_action)
 
-        if test_folder:
+        if os.path.isdir(test_folder):
             test_file_names = [
                 f[5:-3] for f in os.listdir(test_folder) if
                 f.startswith("test_") and f.endswith(".py")
@@ -493,7 +496,6 @@ class ScriptAssistant:
                 "current_configuration",
                 self.dlg_settings.cmb_config.lineEdit().text()
             )
-
 
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -378,48 +378,60 @@ class ScriptAssistant:
 
     def print_aggregated_result(self):
         """Print a summary of all tests to the QGIS Python Console"""
-        print ""
-        for e in self.aggregated_test_result.errors:
-            print e[0]
-            print "-" * len(e[0].__str__())
-            print e[1]
-        for f in self.aggregated_test_result.failures:
-            print f[0]
-            print "-" * len(f[0].__str__())
-            print f[1]
-        successes = self.aggregated_test_result.testsRun - (
-            len(self.aggregated_test_result.errors) +
-            len(self.aggregated_test_result.failures) +
-            len(self.aggregated_test_result.expectedFailures) +
-            len(self.aggregated_test_result.unexpectedSuccesses) +
-            len(self.aggregated_test_result.skipped)
-        )
-        print """
-+---------------------------+------------+
-| Successes                 |       {successes: >{fill}} |
-+---------------------------+------------+
-| Errors                    |       {errors: >{fill}} |
-+---------------------------+------------+
-| Failures                  |       {failures: >{fill}} |
-+---------------------------+------------+
-| Expected Failures         |       {expected: >{fill}} |
-+---------------------------+------------+
-| Unexpected Successes      |       {unexpected: >{fill}} |
-+---------------------------+------------+
-| Skipped                   |       {skipped: >{fill}} |
-+===========================+============+
+        if self.aggregated_test_result.testsRun:
+            print ""
+            for e in self.aggregated_test_result.errors:
+                print e[0]
+                print "-" * len(e[0].__str__())
+                print e[1]
+                print ""
+            for f in self.aggregated_test_result.failures:
+                print f[0]
+                print "-" * len(f[0].__str__())
+                print f[1]
+                print ""
+            for g in self.aggregated_test_result.unexpectedSuccesses:
+                print "UNEXPECTED SUCCESS: {0}".format(g)
+                print ""
+
+            successes = self.aggregated_test_result.testsRun - (
+                len(self.aggregated_test_result.errors) +
+                len(self.aggregated_test_result.failures) +
+                len(self.aggregated_test_result.expectedFailures) +
+                len(self.aggregated_test_result.unexpectedSuccesses) +
+                len(self.aggregated_test_result.skipped)
+            )
+
+            self.print_table_row("Successes", successes)
+            self.print_table_row("Errors", len(self.aggregated_test_result.errors))
+            self.print_table_row("Failures", len(self.aggregated_test_result.failures))
+            self.print_table_row("Expected Failures", len(self.aggregated_test_result.expectedFailures))
+            self.print_table_row("Unexpected Successes", len(self.aggregated_test_result.unexpectedSuccesses))
+            self.print_table_row("Skipped", len(self.aggregated_test_result.skipped))
+
+            print """+===========================+============+
 | Total                     |       {total: >{fill}} |
 +---------------------------+------------+
-        """.format(
-            successes=successes,
-            errors=len(self.aggregated_test_result.errors),
-            failures=len(self.aggregated_test_result.failures),
-            expected=len(self.aggregated_test_result.expectedFailures),
-            unexpected=len(self.aggregated_test_result.unexpectedSuccesses),
-            skipped=len(self.aggregated_test_result.skipped),
-            total=self.aggregated_test_result.testsRun,
-            fill='4'
-        )
+            """.format(
+                total=self.aggregated_test_result.testsRun,
+                fill='4'
+            )
+
+        else:
+            print ""
+            print "No tests were run."
+            print ""
+
+    @staticmethod
+    def print_table_row(result_type, count):
+        if count:
+            print """+---------------------------+------------+
+| {result_type: <{text_fill}} | {count: >{count_fill}} |""".format(
+                result_type=result_type,
+                text_fill='25',
+                count=count,
+                count_fill='10'
+            )
 
     def open_python_console(self):
         """Ensures that the QGIS Python Console is visible to the user."""

--- a/scriptassistant/plugin.py
+++ b/scriptassistant/plugin.py
@@ -89,7 +89,6 @@ class ScriptAssistant:
                 gui.settings_manager.save_setting("script_folder", "")
                 gui.settings_manager.save_setting("test_folder", os.path.join(__location__, "tests"))
                 gui.settings_manager.save_setting("test_data_folder", "")
-                gui.settings_manager.save_setting("view_tests", "N")
                 gui.settings_manager.save_setting("no_reload", "N")
                 gui.settings_manager.save_setting("current_test", "$ALL")
 
@@ -100,7 +99,6 @@ class ScriptAssistant:
                 settings.setValue("test_data_folder", "")
                 settings.setValue("test_folder", os.path.join(__location__, "tests"))
                 settings.setValue("no_reload", "N")
-                settings.setValue("view_tests", "N")
                 settings.endArray()
 
         self.create_reload_action()
@@ -459,20 +457,8 @@ class ScriptAssistant:
             pass
         else:
             reload(module)
-        run_tests = getattr(module, "run_tests")
-        if gui.settings_manager.load_setting("view_tests") == "Y":
-            try:
-                result = run_tests(view_tests=True)
-            except TypeError:
-                self.iface.messageBar().pushMessage(
-                    self.tr("Could Not Repaint Widgets"),
-                    self.tr("Tests configured to repaint widgets, but test script doesn't support this."),
-                    level=QgsMessageBar.INFO,
-                )
-                result = run_tests()
-        else:
-            suite = unittest.TestLoader().loadTestsFromModule(module)
-            result = unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)
+        suite = unittest.TestLoader().loadTestsFromModule(module)
+        result = unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)
         return result
 
     @pyqtSlot()
@@ -504,12 +490,10 @@ class ScriptAssistant:
     def open_settings_dialog(self):
         """Open the settings dialog and show the current configuration."""
         self.dlg_settings.show()
-
         self.dlg_settings.populate_config_combo()
 
         if gui.settings_manager.load_setting("current_configuration"):
             self.dlg_settings.show_last_configuration()
-
             self.dlg_settings.check_changes()
 
         result = self.dlg_settings.exec_()
@@ -595,11 +579,6 @@ class ScriptAssistant:
             gui.settings_manager.save_setting("no_reload", "Y")
         else:
             gui.settings_manager.save_setting("no_reload", "N")
-
-        if self.dlg_settings.chk_repaint.isChecked():
-            gui.settings_manager.save_setting("view_tests", "Y")
-        else:
-            gui.settings_manager.save_setting("view_tests", "N")
 
         if self.dlg_settings.cmb_config.lineEdit().text():
             gui.settings_manager.save_setting(

--- a/scriptassistant/tests/__init__.py
+++ b/scriptassistant/tests/__init__.py
@@ -1,1 +1,12 @@
 # -*- coding: utf-8 -*-
+
+import sys
+import unittest
+
+from test_script_assistant import ScriptAssistantSettingsTest
+
+
+def run_tests():
+    suite = unittest.TestSuite()
+    suite.addTests(unittest.makeSuite(ScriptAssistantSettingsTest, "test"))
+    unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)

--- a/scriptassistant/tests/test_script_assistant.py
+++ b/scriptassistant/tests/test_script_assistant.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
-import time
 import unittest
 
-from qgis.core import QgsApplication, QgsMapLayerRegistry
-from qgis.gui import QgsMessageBar
-from qgis.utils import plugins, iface
+from qgis.core import QgsApplication
+from qgis.utils import plugins
 
 __location__ = os.path.realpath(
     os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -34,20 +31,11 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
         self.dlg.show()
         self.dlg.populate_config_combo()
         self.dlg.show_last_configuration()
-        self.view(self.dlg)
 
     def tearDown(self):
         """Runs after each test."""
         self.dlg.close()
-        self.view(self.dlg)
         pass
-
-    def view(self, qt_object):
-        if view_tests_during_execution:
-            qt_object.repaint()
-            time.sleep(1)
-        else:
-            pass
 
     def test_correct_script_assistant_test_settings(self):
         self.assertEqual(self.dlg.cmb_config.lineEdit().text(), "Script Assistant")
@@ -61,7 +49,6 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
     def test_deleting_settings(self):
         count = self.dlg.cmb_config.count()
         self.dlg.btn_delete.clicked.emit(True)
-        self.view(self.dlg)
         if count == 1:
             self.assertTrue(self.dlg.btn_save.isEnabled())
             self.assertFalse(self.dlg.btn_delete.isEnabled())
@@ -80,15 +67,12 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
         self.dlg.chk_reload.setChecked(False)
         self.dlg.chk_repaint.setChecked(True)
         self.dlg.btn_save.clicked.emit(True)
-        self.view(self.dlg)
 
     def test_adding_new_settings(self):
         self.dlg.cmb_config.lineEdit().setText("Script Assistant Test")
-        self.view(self.dlg)
         self.assertIn("*", self.dlg.windowTitle())
         self.dlg.lne_test_data.setText(os.path.join(__location__, "tests", "testdata"))
         self.assertTrue(self.dlg.btn_save.isEnabled())
-        self.view(self.dlg)
         self.dlg.btn_save.clicked.emit(True)
         self.assertEqual(self.dlg.cmb_config.lineEdit().text(), "Script Assistant Test")
         self.assertEqual(self.dlg.lne_test_data.text(), os.path.join(__location__, "tests", "testdata"))
@@ -96,24 +80,20 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
         self.assertTrue(self.dlg.btn_delete.isEnabled())
         self.dlg.btn_delete.clicked.emit(True)
         self.dlg.cmb_config.setCurrentIndex(self.dlg.cmb_config.findText("Script Assistant"))
-        self.view(self.dlg)
 
     def test_running_script_test(self):
-        self.view(self.dlg)
         self.dlg.lne_test.setText(os.path.join(__location__, "tests"))
         self.assertIn("*", self.dlg.windowTitle())
         self.dlg.btn_save.clicked.emit(True)
         self.assertNotIn("*", self.dlg.windowTitle())
         self.scriptassistant.save_settings()
         self.dlg.close()
-        self.view(self.dlg)
         for action in self.scriptassistant.test_actions:
             if action.text() == "add_area_column":
                 action.triggered.emit(True)
         self.dlg.show()
         self.dlg.populate_config_combo()
         self.dlg.show_last_configuration()
-        self.view(self.dlg)
         self.dlg.lne_test.setText(__location__)
         self.dlg.lne_test_data.setText("")
         self.dlg.btn_save.clicked.emit(True)
@@ -127,45 +107,19 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
         plugins["processing"].toolbox.updateProvider("script")
 
     def test_running_plugin_test(self):
-        self.view(self.dlg)
         self.dlg.lne_test.setText(os.path.join(__location__, "tests"))
         self.assertIn("*", self.dlg.windowTitle())
         self.dlg.btn_save.clicked.emit(True)
         self.assertNotIn("*", self.dlg.windowTitle())
         self.scriptassistant.save_settings()
         self.dlg.close()
-        self.view(self.dlg)
         for action in self.scriptassistant.test_actions:
             if action.text() == "plugin":
                 action.triggered.emit(True)
         self.dlg.show()
         self.dlg.populate_config_combo()
         self.dlg.show_last_configuration()
-        self.view(self.dlg)
         self.dlg.lne_test.setText(__location__)
         self.dlg.lne_test_data.setText("")
         self.dlg.btn_save.clicked.emit(True)
         self.scriptassistant.save_settings()
-
-
-def run_tests(view_tests=False):
-    global view_tests_during_execution
-    if view_tests:
-        view_tests_during_execution = True
-    else:
-        view_tests_during_execution = False
-    suite = unittest.TestSuite()
-    suite.addTests(unittest.makeSuite(ScriptAssistantSettingsTest, "test"))
-    result = unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)
-    if result.wasSuccessful():
-        iface.messageBar().pushMessage(
-            "All Tests Passed",
-            "Testing was successful.",
-            level=QgsMessageBar.SUCCESS,
-        )
-    else:
-        iface.messageBar().pushMessage(
-            "Test Failure",
-            "Testing was not successful.",
-            level=QgsMessageBar.CRITICAL,
-        )

--- a/scriptassistant/tests/test_script_assistant.py
+++ b/scriptassistant/tests/test_script_assistant.py
@@ -56,7 +56,6 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
             self.assertEqual(self.dlg.lne_test.text(), "")
             self.assertEqual(self.dlg.lne_test_data.text(), "")
             self.assertFalse(self.dlg.chk_reload.isChecked())
-            self.assertFalse(self.dlg.chk_repaint.isChecked())
             self.assertIn("*", self.dlg.windowTitle())
         else:
             self.assertEqual(count - 1, self.dlg.cmb_config.count())
@@ -65,7 +64,6 @@ class ScriptAssistantSettingsTest(unittest.TestCase):
         self.dlg.lne_test.setText(__location__)
         self.dlg.lne_test_data.setText("")
         self.dlg.chk_reload.setChecked(False)
-        self.dlg.chk_repaint.setChecked(True)
         self.dlg.btn_save.clicked.emit(True)
 
     def test_adding_new_settings(self):

--- a/scriptassistant/tests/tests/test_add_area_column.py
+++ b/scriptassistant/tests/tests/test_add_area_column.py
@@ -4,14 +4,12 @@
 testing Script Assistant plugin functionality.
 """
 
-import sys
 import os
 import unittest
 from shutil import copy
 
 from qgis.core import QgsVectorLayer
-from qgis.gui import QgsMessageBar
-from qgis.utils import plugins, QGis, iface
+from qgis.utils import plugins, QGis
 
 import processing
 from processing.core.Processing import Processing
@@ -65,25 +63,3 @@ class AddAreaColumnTest(unittest.TestCase):
     def test_valid_output(self):
         """Ensure that an output layer has been created with expected rows."""
         self.assertEqual(output_layer.featureCount(), 1)
-
-
-def run_tests():
-    """
-    Implements a TextTestRunner, which is a basic test runner implementation
-    that prints results on standard error.
-    """
-    suite = unittest.TestSuite()
-    suite.addTests(unittest.makeSuite(AddAreaColumnTest, "test"))
-    result = unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)
-    if result.wasSuccessful():
-        iface.messageBar().pushMessage(
-            "All Tests Passed",
-            "Testing was successful.",
-            level=QgsMessageBar.SUCCESS,
-        )
-    else:
-        iface.messageBar().pushMessage(
-            "Test Failure",
-            "Testing was not successful.",
-            level=QgsMessageBar.CRITICAL,
-        )

--- a/scriptassistant/tests/tests/test_plugin.py
+++ b/scriptassistant/tests/tests/test_plugin.py
@@ -5,19 +5,14 @@ testing Script Assistant plugin functionality.
 """
 
 import os
-import sys
-import time
 import unittest
 
-from qgis.gui import QgsMessageBar
-from qgis.utils import plugins, iface
+from qgis.utils import plugins
 
 from scriptassistant.plugin import ScriptAssistant
 
 __location__ = os.path.realpath(
     os.path.join(os.getcwd(), os.path.dirname(__file__)))
-
-view_tests_during_execution = False
 
 
 class QGISTest(unittest.TestCase):
@@ -27,35 +22,5 @@ class QGISTest(unittest.TestCase):
         """Runs before each test."""
         self.scriptassistant = plugins.get("scriptassistant")
 
-    def view(self, qt_object):
-        if view_tests_during_execution:
-            qt_object.repaint()
-            time.sleep(1)
-        else:
-            pass
-
     def test_plugin(self):
         self.assertIsInstance(self.scriptassistant, ScriptAssistant)
-
-
-def run_tests(view_tests=False):
-    global view_tests_during_execution
-    if view_tests:
-        view_tests_during_execution = True
-    else:
-        view_tests_during_execution = False
-    suite = unittest.TestSuite()
-    suite.addTests(unittest.makeSuite(QGISTest, "test"))
-    result = unittest.TextTestRunner(verbosity=2, stream=sys.stdout).run(suite)
-    if result.wasSuccessful():
-        iface.messageBar().pushMessage(
-            "All Tests Passed",
-            "Testing was successful.",
-            level=QgsMessageBar.SUCCESS,
-        )
-    else:
-        iface.messageBar().pushMessage(
-            "Test Failure",
-            "Testing was not successful.",
-            level=QgsMessageBar.CRITICAL,
-        )


### PR DESCRIPTION
Closes #9
Closes #10

- Subfolders are now included in test discovery
- A final summary of the test results is printed to the QGIS Python Console after all testing
- Uses `unittest.TestLoader().discover()` instead of custom function to discover tests